### PR TITLE
Add rollup-plugin-babel-minify plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   "directories": {
     "lib": "./src"
   },
+  "files": [
+    "src/index.js",
+    "fluent-web.js"
+  ],
   "main": "./fluent-web.js",
   "module": "./src/index.js",
   "keywords": [
@@ -54,6 +58,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-mocha": "^5.3.0",
     "rollup": "^1.20.0",
+    "rollup-plugin-babel-minify": "^9.0.0",
     "rollup-plugin-node-resolve": "^5.2.0"
   }
 }

--- a/rollup_config.js
+++ b/rollup_config.js
@@ -1,4 +1,5 @@
 import resolve from 'rollup-plugin-node-resolve';
+import minify from 'rollup-plugin-babel-minify';
 
 export default {
   output: {
@@ -10,6 +11,10 @@ export default {
   plugins: [
     resolve({
       browser: true,
+    }),
+    minify({
+      // Options for babel-minify.
+      comments: false
     })
   ]
 };


### PR DESCRIPTION
Seems to drop the module size to ~11kB (31.7kB unpacked).

```sh
$ npm pack --dry-run

npm notice 📦  @fluent/web@0.2.0
npm notice === Tarball Contents ===
npm notice 1.4kB  package.json
npm notice 418B   CHANGELOG.md
npm notice 25.7kB fluent-web.js
npm notice 2.0kB  README.md
npm notice 2.1kB  src/index.js

npm notice === Tarball Details ===
npm notice name:          @fluent/web
npm notice version:       0.2.0
npm notice filename:      fluent-web-0.2.0.tgz
npm notice package size:  10.8 kB
npm notice unpacked size: 31.7 kB
npm notice shasum:        bc876b584121ec558f1147ae853394db661b1f6a
npm notice integrity:     sha512-99HCSyGOt+jcv[...]z3nTD71MYJmjw==
npm notice total files:   5
npm notice
fluent-web-0.2.0.tgz
```

Fixes #7 